### PR TITLE
feat(sts): add non-owning client for STS	operations to make method chaining ergonomic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "aliyuncs",
         "dotenv",
         "HMAC",
-        "reqwest"
+        "reqwest",
+        "thiserror"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "Aliyun",
         "aliyuncs",
+        "chrono",
         "dotenv",
         "HMAC",
         "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "thiserror",
  "tokio",
  "uuid",
 ]
@@ -1025,18 +1026,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,12 +73,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bitflags"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,20 +253,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -616,7 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -740,6 +734,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1205,7 +1205,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1232,12 +1232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1537,13 +1537,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "write16"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "thiserror",
  "tokio",
  "uuid",
 ]
@@ -1032,18 +1033,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ version = "0.1.1"
 dependencies = [
  "base64",
  "chrono",
+ "claims",
  "dotenv",
  "hmac",
  "once_cell",
@@ -132,6 +133,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.0",
 ]
+
+[[package]]
+name = "claims"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba18ee93d577a8428902687bcc2b6b45a56b1981a1f6d779731c86cc4c5db18"
 
 [[package]]
 name = "core-foundation-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ sha1 = "0.10.6"
 base64 = "0.22.1"
 percent-encoding = "2.3.1"
 uuid = { version = "1.16.0", features = ["v4"] }
+thiserror = "2.0.17"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,14 @@ exclude = [
 ]
 
 [dependencies]
-tokio = { version = "1.45.0", default-features = false, features = ["rt", "macros"] }
-reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls"] }
+tokio = { version = "1.45.0", default-features = false, features = [
+    "rt",
+    "macros",
+] }
+reqwest = { version = "0.12.15", default-features = false, features = [
+    "json",
+    "rustls-tls",
+] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
 chrono = "0.4.42"
@@ -40,4 +46,11 @@ tag-prefix = ""
 tag-name = "{{prefix}}{{version}}"
 pre-release-commit-message = "chore: release {{crate_name}} version {{version}}"
 tag-message = "chore: release {{crate_name}} version {{version}}"
-pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--tag", "{{version}}" ]
+pre-release-hook = [
+    "git",
+    "cliff",
+    "-o",
+    "CHANGELOG.md",
+    "--tag",
+    "{{version}}",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ sha1 = "0.10.6"
 base64 = "0.22.1"
 percent-encoding = "2.3.1"
 uuid = { version = "1.18.1", features = ["v4"] }
+thiserror = "2.0.17"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ uuid = { version = "1.18.1", features = ["v4"] }
 thiserror = "2.0.17"
 
 [dev-dependencies]
+claims = "0.8.0"
 dotenv = "0.15.0"
 once_cell = "1.21.3"
 

--- a/README.md
+++ b/README.md
@@ -78,5 +78,8 @@ async fn main() {
     // Query available regions
     let regions = describe_regions(&client, None).await.unwrap();
     println!("Available regions: {:?}", regions);
+    // Get current caller identity
+    let caller_identity = client.sts().get_caller_identity().await.unwrap();
+    println!("Current caller identity: {:?}", caller_identity);
 }
 ```

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 fn default_aliyun_rejection_field() -> String {
     "No content. If you see this please submit a bug issue (to the rust sdk repo).".to_string()
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct AliyunRejection {
     pub code: String,

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,15 +1,34 @@
 use std::error::Error;
 
+use serde::Deserialize;
 use thiserror::Error;
+
+fn default_aliyun_rejection_field() -> String {
+    "No content. If you see this please submit a bug issue (to the rust sdk repo).".to_string()
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct AliyunRejection {
+    pub code: String,
+    pub host_id: String,
+    #[serde(default = "default_aliyun_rejection_field")]
+    pub message: String,
+    pub request_id: String,
+    #[serde(default = "default_aliyun_rejection_field")]
+    pub recommend: String,
+}
 
 #[derive(Error, Debug)]
 pub enum AdvancedClientError {
+    #[error("Aliyun rejected the request and returned an error")]
+    AliyunRejectError(AliyunRejection),
     #[error("When using the underlying client to send request it throw an error: {0}")]
     UnderlyingError(
         #[source]
         #[from]
         Box<dyn Error>,
     ),
-    #[error("When trying to deserialization the result an error occurred")]
+    #[error("When trying to deserialization the result an error occurred. This should not happened; please using services to debug and open a bug issue")]
     ResultDeserializationError(#[from] serde_json::Error),
 }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -5,7 +5,11 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum AdvancedClientError {
     #[error("When using the underlying client to send request it throw an error: {0}")]
-    UnderlyingError(#[source] Box<dyn Error>),
+    UnderlyingError(
+        #[source]
+        #[from]
+        Box<dyn Error>,
+    ),
     #[error("When trying to deserialization the result an error occurred")]
-    ResultDeserializationError(serde_json::Error),
+    ResultDeserializationError(#[from] serde_json::Error),
 }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -7,6 +7,10 @@ fn default_aliyun_rejection_field() -> String {
     "No content. If you see this please submit a bug issue (to the rust sdk repo).".to_string()
 }
 
+/// Represents an error response returned by the Aliyun server.
+///
+/// The response fields use PascalCase naming convention to match
+/// the format returned by the Aliyun API and maintain consistency.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct AliyunRejection {

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,0 +1,11 @@
+use std::error::Error;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AdvancedClientError {
+    #[error("When using the underlying client to send request it throw an error: {0}")]
+    UnderlyingError(#[source] Box<dyn Error>),
+    #[error("When trying to deserialization the result an error occurred")]
+    ResultDeserializationError(serde_json::Error),
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,8 +1,8 @@
 pub mod sts;
 pub mod error;
+pub(crate) mod utils;
 
 use crate::signing;
-use crate::utils;
 use chrono::Utc;
 use reqwest;
 use serde_json::Value;
@@ -66,8 +66,8 @@ impl AliyunClient {
             .map(|(k, v)| {
                 format!(
                     "{}={}",
-                    utils::aliyun_percent_encode(k),
-                    utils::aliyun_percent_encode(v)
+                    crate::utils::aliyun_percent_encode(k),
+                    crate::utils::aliyun_percent_encode(v)
                 )
             })
             .collect::<Vec<String>>()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,6 @@
+pub mod sts;
+pub mod error;
+
 use crate::signing;
 use crate::utils;
 use chrono::Utc;

--- a/src/client/sts/caller_identity.rs
+++ b/src/client/sts/caller_identity.rs
@@ -1,0 +1,20 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub enum IdentityType {
+    Account,
+    RAMUser,
+    AssumedRoleUser,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct CallerIdentityBody {
+    pub identity_type: IdentityType,
+    pub request_id: String,
+    pub account_id: String,
+    pub principal_id: String,
+    pub user_id: String,
+    pub arn: String,
+    pub role_id: Option<String>,
+}

--- a/src/client/sts/caller_identity.rs
+++ b/src/client/sts/caller_identity.rs
@@ -1,13 +1,13 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum IdentityType {
     Account,
     RAMUser,
     AssumedRoleUser,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct CallerIdentityBody {
     pub identity_type: IdentityType,

--- a/src/client/sts/mod.rs
+++ b/src/client/sts/mod.rs
@@ -15,13 +15,8 @@ impl<'a> STSClient<'a> {
     }
 
     pub async fn get_caller_identity(&self) -> Result<CallerIdentityBody, AdvancedClientError> {
-        let response = get_caller_identity(&self.client)
-            .await
-            .map_err(|e| AdvancedClientError::UnderlyingError(e))?;
-
-        let deserialized = serde_json::from_value::<CallerIdentityBody>(response)
-            .map_err(|e| AdvancedClientError::ResultDeserializationError(e))?;
-
+        let response = get_caller_identity(&self.client).await?;
+        let deserialized = serde_json::from_value::<CallerIdentityBody>(response)?;
         Result::Ok(deserialized)
     }
 }

--- a/src/client/sts/mod.rs
+++ b/src/client/sts/mod.rs
@@ -1,0 +1,46 @@
+pub mod caller_identity;
+
+use crate::{
+    client::{error::AdvancedClientError, sts::caller_identity::CallerIdentityBody, AliyunClient},
+    services::sts::get_caller_identity,
+};
+
+pub struct STSClient<'a> {
+    pub client: &'a AliyunClient,
+}
+
+impl<'a> STSClient<'a> {
+    pub fn new(client: &'a AliyunClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn get_caller_identity(&self) -> Result<CallerIdentityBody, AdvancedClientError> {
+        let response = get_caller_identity(&self.client)
+            .await
+            .map_err(|e| AdvancedClientError::UnderlyingError(e))?;
+
+        let deserialized = serde_json::from_value::<CallerIdentityBody>(response)
+            .map_err(|e| AdvancedClientError::ResultDeserializationError(e))?;
+
+        Result::Ok(deserialized)
+    }
+}
+
+impl AliyunClient {
+    pub fn sts<'a>(&'a self) -> STSClient<'a> {
+        STSClient { client: self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::create_aliyun_client;
+
+    #[tokio::test]
+    async fn test_get_caller_identity() {
+        let client = create_aliyun_client();
+        let sts_client = client.sts();
+        let result_body = sts_client.get_caller_identity().await.unwrap();
+        println!("{:?}", result_body);
+    }
+}

--- a/src/client/sts/mod.rs
+++ b/src/client/sts/mod.rs
@@ -42,5 +42,13 @@ mod tests {
         let sts_client = client.sts();
         let result_body = sts_client.get_caller_identity().await.unwrap();
         println!("{:?}", result_body);
+
+        // use chain calling
+        let result_body = client
+            .sts()
+            .get_caller_identity()
+            .await
+            .expect("Chain calling failed");
+        println!("{:?}", result_body);
     }
 }

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -1,0 +1,21 @@
+use std::fmt::Debug;
+
+use serde::Deserialize;
+
+use crate::client::error::{AdvancedClientError, AliyunRejection};
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ResponseFromAliyun<R: Debug> {
+    Normal(R),
+    Rejected(AliyunRejection),
+}
+
+pub fn parse_json_value<R: Debug + for<'de> Deserialize<'de>>(
+    value: serde_json::Value,
+) -> Result<R, AdvancedClientError> {
+    match serde_json::from_value::<ResponseFromAliyun<R>>(value)? {
+        ResponseFromAliyun::Normal(result) => Ok(result),
+        ResponseFromAliyun::Rejected(err) => Err(AdvancedClientError::AliyunRejectError(err)),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod signing;
 pub mod utils;
 
 #[cfg(test)]
+#[macro_use]
 pub mod test_utils;

--- a/src/services/sts.rs
+++ b/src/services/sts.rs
@@ -47,11 +47,11 @@ pub async fn get_caller_identity(client: &AliyunClient) -> Result<Value, Box<dyn
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::create_aliyun_client;
+    use crate::test_utils::{create_aliyun_client, EMPTY, GLOBAL_TEST_SECRETS};
 
     #[tokio::test]
     async fn test_get_caller_identity() {
-        let client = create_aliyun_client();
+        let client = create_aliyun_client::<GLOBAL_TEST_SECRETS>();
 
         let result = get_caller_identity(&client).await;
         println!("get_caller_identity: {:?}", result);
@@ -66,5 +66,9 @@ mod tests {
         assert!(response.get("Arn").is_some());
         // Returned only when the current caller is a RAM role.
         // assert!(response.get("RoleId").is_some());
+
+        let empty_credentials_client = create_aliyun_client::<EMPTY>();
+        let result = get_caller_identity(&empty_credentials_client).await;
+        println!("get_caller_identity (empty credentials): {:?}", result);
     }
 }

--- a/src/services/sts.rs
+++ b/src/services/sts.rs
@@ -8,6 +8,7 @@ use std::{collections::BTreeMap, error::Error};
 /// - Request Domain: sts.aliyuncs.com
 /// - API Version: 2015-04-01
 /// - Description: This API returns information about the caller's identity.
+/// - Aliyun Document Link: https://help.aliyun.com/zh/ram/developer-reference/api-sts-2015-04-01-getcalleridentity
 ///
 /// **Input Parameters:**
 ///
@@ -27,7 +28,7 @@ use std::{collections::BTreeMap, error::Error};
 ///
 /// | Field       | Type   | Description                                                      |
 /// |-------------|--------|------------------------------------------------------------------|
-/// | IdentityType| String | Type of identity (e.g., "User", "Role")                          |
+/// | IdentityType| String | Type of identity ("Account", "RAMUser", "AssumedRoleUser")                          |
 /// | RequestId   | String | Unique request ID                                                |
 /// | AccountId   | String | Alibaba Cloud account ID                                         |
 /// | PrincipalId | String | Principal identifier                                             |
@@ -46,16 +47,11 @@ pub async fn get_caller_identity(client: &AliyunClient) -> Result<Value, Box<dyn
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::AliyunClient;
-    use crate::test_utils::TEST_SECRETS;
-    use tokio;
+    use crate::test_utils::create_aliyun_client;
 
     #[tokio::test]
     async fn test_get_caller_identity() {
-        let client = AliyunClient::new(
-            TEST_SECRETS.access_key_id.clone(),
-            TEST_SECRETS.access_key_secret.clone(),
-        );
+        let client = create_aliyun_client();
 
         let result = get_caller_identity(&client).await;
         println!("get_caller_identity: {:?}", result);

--- a/src/test_utils/error.rs
+++ b/src/test_utils/error.rs
@@ -1,30 +1,11 @@
 use std::env;
+use thiserror::Error;
 
 /// Error type for test secrets loading failures
-#[derive(Debug)]
-pub enum TestSecretsError {
-    AccessKeyId(env::VarError),
-    AccessKeySecret(env::VarError),
-}
-
-impl std::fmt::Display for TestSecretsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TestSecretsError::AccessKeyId(e) => {
-                write!(f, "Failed to get TEST_ACCESS_KEY_ID: {}", e)
-            }
-            TestSecretsError::AccessKeySecret(e) => {
-                write!(f, "Failed to get TEST_ACCESS_KEY_SECRET: {}", e)
-            }
-        }
-    }
-}
-
-impl std::error::Error for TestSecretsError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            TestSecretsError::AccessKeyId(e) => Some(e),
-            TestSecretsError::AccessKeySecret(e) => Some(e),
-        }
-    }
+#[derive(Debug, Error)]
+#[error("Failed to get test credential from environment variable '{var_name}': {source}")]
+pub struct TestSecretsError {
+    pub var_name: String,
+    #[source]
+    pub source: env::VarError,
 }

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -5,6 +5,8 @@ pub use error::TestSecretsError;
 use once_cell::sync::Lazy;
 use std::env;
 
+use crate::client::AliyunClient;
+
 pub struct TestSecrets {
     pub access_key_id: String,
     pub access_key_secret: String,
@@ -35,3 +37,10 @@ impl TestSecrets {
 
 pub static TEST_SECRETS: Lazy<TestSecrets> =
     Lazy::new(|| TestSecrets::from_env().expect("Failed to load test secrets from environment"));
+
+pub fn create_aliyun_client() -> AliyunClient {
+    AliyunClient::new(
+        TEST_SECRETS.access_key_id.clone(),
+        TEST_SECRETS.access_key_secret.clone(),
+    )
+}

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -23,10 +23,14 @@ impl TestSecrets {
         // debugging tests inside the IDE.
         let _ = dotenv::dotenv();
 
-        let access_key_id =
-            env::var("TEST_ACCESS_KEY_ID").map_err(TestSecretsError::AccessKeyId)?;
-        let access_key_secret =
-            env::var("TEST_ACCESS_KEY_SECRET").map_err(TestSecretsError::AccessKeySecret)?;
+        let access_key_id = env::var("TEST_ACCESS_KEY_ID").map_err(|e| TestSecretsError {
+            var_name: "TEST_ACCESS_KEY_ID".to_string(),
+            source: e,
+        })?;
+        let access_key_secret = env::var("TEST_ACCESS_KEY_SECRET").map_err(|e| TestSecretsError {
+            var_name: "TEST_ACCESS_KEY_SECRET".to_string(),
+            source: e,
+        })?;
 
         Ok(TestSecrets {
             access_key_id,

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -38,9 +38,77 @@ impl TestSecrets {
 pub static TEST_SECRETS: Lazy<TestSecrets> =
     Lazy::new(|| TestSecrets::from_env().expect("Failed to load test secrets from environment"));
 
-pub fn create_aliyun_client() -> AliyunClient {
-    AliyunClient::new(
-        TEST_SECRETS.access_key_id.clone(),
-        TEST_SECRETS.access_key_secret.clone(),
-    )
+#[allow(non_camel_case_types)]
+pub enum AliyunClientCreationVariant {
+    GLOBAL_TEST_SECRETS,
+    EMPTY,
+}
+
+pub trait ClientCredentialProvider {
+    fn get_credentials() -> (String, String);
+}
+
+#[allow(non_camel_case_types)]
+pub struct GLOBAL_TEST_SECRETS;
+#[allow(non_camel_case_types)]
+pub struct EMPTY;
+#[allow(non_camel_case_types)]
+pub struct INVALID;
+
+impl ClientCredentialProvider for GLOBAL_TEST_SECRETS {
+    fn get_credentials() -> (String, String) {
+        (
+            TEST_SECRETS.access_key_id.clone(),
+            TEST_SECRETS.access_key_secret.clone(),
+        )
+    }
+}
+
+impl ClientCredentialProvider for EMPTY {
+    fn get_credentials() -> (String, String) {
+        ("".to_owned(), "".to_owned())
+    }
+}
+
+impl ClientCredentialProvider for INVALID {
+    fn get_credentials() -> (String, String) {
+        (
+            "INVALID-ACCESS-TOKEN".to_owned(),
+            "INVALID-ACCESS_SECRET".to_owned(),
+        )
+    }
+}
+
+pub fn create_aliyun_client<P: ClientCredentialProvider>() -> AliyunClient {
+    let credentials = P::get_credentials();
+    AliyunClient::new(credentials.0, credentials.1)
+}
+
+/// Macro to test multiple credential providers that should fail.
+/// 
+/// # Example
+/// ```ignore
+/// use crate::test_utils::{EMPTY, INVALID};
+/// 
+/// test_invalid_clients! {
+///     [EMPTY => "EMPTY", INVALID => "INVALID"],
+///     |client, name| async {
+///         println!("Testing {} credentials...", name);
+///         let result = client.sts().get_caller_identity().await;
+///         assert_matches!(result, Err(AdvancedClientError::AliyunRejectError(_)));
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! test_multiple_clients {
+    ([$($provider:ty => $name:expr),* $(,)?], |$client:ident, $name_var:ident| $test_fn:expr) => {
+        $(
+            {
+                let $client = $crate::test_utils::create_aliyun_client::<$provider>();
+                let $name_var = $name;
+                let test_closure = $test_fn;
+                test_closure.await;
+            }
+        )*
+    };
 }


### PR DESCRIPTION
I try to add a non-owning client for STS operations in this PR to enable ergonomic method chaining. If you think it's not a bad idea I can add such clients for ecs and billing service, so that user can easily find suitable API once the number of the implemented APIs goes big by just using method chaining such as `client.sts().get_caller_identity()`.

I also make the struct returned by the function calling of wrapper client to be detailed struct rather than `Value` struct from the `serde_json` crate.

The newly created wrapper client has been tested through running the test case in this PR.

Besides, I made some changes listed as below:

+ chore(IDE): Add some c-spell words to workspace
+ chore(fmt): reformat the cargo.toml file
+ feat(error): add `thiserror` to make error development more ergonomic
+ fix(docs): fix the errors in the doc of `get_caller_identity`
+ refactor(tests): abstract the client creation for test cases
